### PR TITLE
Update developer ID

### DIFF
--- a/data/com.rafaelmardojai.Blanket.metainfo.xml.in
+++ b/data/com.rafaelmardojai.Blanket.metainfo.xml.in
@@ -40,7 +40,7 @@
   <url type="vcs-browser">https://github.com/rafaelmardojai/blanket</url>
   <!-- developer_name tag deprecated with Appstream 1.0 -->
   <developer_name translatable="no">Rafael Mardojai CM</developer_name>
-  <developer id="github.com">
+  <developer id="com.rafaelmardojai">
       <name translatable="no">Rafael Mardojai CM</name>
   </developer>
   <update_contact>email_AT_rafaelmardojai.com</update_contact>


### PR DESCRIPTION
Appstream decided to use reverse DNS for developer IDds.

More information: https://github.com/ximion/appstream/issues/575